### PR TITLE
ci: skip sonarqube on forked-repo PRs and dashgit branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,12 @@ jobs:
   sonarqube:
     needs: [test-java]
     #if: ${{ false }}  # disable for now
-    #This job fails when comming from a dependabot PR (can't read the sonarqube token for security reasons).
+    #This job fails when comming from a dependabot PR or a forked repo
+    #(can't read the sonarqube token for security reasons).
     #Links to discussions and workaround at: https://github.com/giis-uniovi/samples-giis-template/issues/4
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    #Also skipped on the branches merged by dashgit, that only contain version updates
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
+      && !startsWith(github.ref, 'refs/heads/dashgit/combined/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: javiertuya/sonarqube-action@v1.4.5


### PR DESCRIPTION
The sonarqube job could not read SONAR_TOKEN on PRs coming from a fork, and it
was analysing branches that only contain dependency version bumps.

- exclude forked-repo PRs from the sonarqube job, in addition to dependabot
- exclude pushes to the dashgit/combined/** branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
